### PR TITLE
feat: Add low R-value wall options

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,6 +91,8 @@
                         <option value="13">2x4 Walls (R-13)</option>
                         <option value="21">2x6 Walls (R-21)</option>
                         <option value="29">2x8 Walls (R-29)</option>
+                        <option value="4">No Insulation (Interior Wall) (R-4)</option>
+                        <option value="1">Exterior Sheathing Only (R-1)</option>
                         <option value="custom">Custom R-Value</option>
                         <option value="double-wall">Double Stud Wall (No Thermal Bridge)</option>
                     </select>


### PR DESCRIPTION
Adds two new wall assembly options to the calculator:
- "No Insulation (Interior Wall) (R-4)"
- "Exterior Sheathing Only (R-1)"

These options allow users to model scenarios with minimal or no insulation in wall assemblies.