### PR TITLE
Add Wood Truss and R21+Reflectix Materials

### DIFF
--- a/calculator.js
+++ b/calculator.js
@@ -43,6 +43,7 @@ const FASTENER_CHI_VALUES = {
 const MATERIALS = {
     // Framing
     wood_stud: { r_inch: 1.25, type: 'framing' },
+    wood_truss: { r_inch: 1.25, type: 'framing' },
     steel_stud: { type: 'framing' },
 
     // Mass / Solid
@@ -53,6 +54,7 @@ const MATERIALS = {
 
     // Insulation (Cavity)
     fiberglass_batt: { r_inch: 3.2 },
+    fiberglass_r21_reflectix: { r_inch: 4.9 },
     mineral_wool: { r_inch: 4.2 },
     cellulose: { r_inch: 3.7 },
     spray_foam_open: { r_inch: 3.6 },
@@ -790,7 +792,8 @@ function calculateEffectiveR(assembly) {
 
         } else {
             // Wood: Parallel Path Method
-            const framingFactor = assembly.spacing === '24' ? 0.22 : 0.25;
+            let framingFactor = assembly.spacing === '24' ? 0.22 : 0.25;
+            if (mat === 'wood_truss') framingFactor = 0.12;
 
             const studRPerInch = MATERIALS.wood_stud.r_inch;
             const r_stud = depth * studRPerInch;

--- a/index.html
+++ b/index.html
@@ -147,6 +147,7 @@
                 <label class="text-xs text-gray-500 block mb-1">Material</label>
                 <select id="wallStudMaterial_A" class="input-field text-sm">
                     <option value="wood">Wood</option>
+                    <option value="wood_truss">Wood Truss</option>
                     <option value="steel">Steel</option>
                     <option value="van_ribs">Van Ribs (Metal)</option>
                 </select>
@@ -171,6 +172,7 @@
                             <label class="text-xs text-gray-500 block mb-1">Cavity Insulation</label>
                             <select id="wallCavityInsulation_A" class="input-field text-sm">
                                 <option value="fiberglass_batt">Fiberglass Batt</option>
+                                <option value="fiberglass_r21_reflectix">Fiberglass R-21 + 2x Reflectix</option>
                                 <option value="mineral_wool">Mineral Wool</option>
                                 <option value="cellulose">Cellulose</option>
                                 <option value="havelock_wool">Havelock Wool (Sheep)</option>
@@ -345,6 +347,7 @@
                 <label class="text-xs text-gray-500 block mb-1">Material</label>
                 <select id="wallStudMaterial_B" class="input-field text-sm">
                     <option value="wood">Wood</option>
+                    <option value="wood_truss">Wood Truss</option>
                     <option value="steel">Steel</option>
                     <option value="van_ribs">Van Ribs (Metal)</option>
                 </select>
@@ -369,6 +372,7 @@
                             <label class="text-xs text-gray-500 block mb-1">Cavity Insulation</label>
                             <select id="wallCavityInsulation_B" class="input-field text-sm">
                                 <option value="fiberglass_batt">Fiberglass Batt</option>
+                                <option value="fiberglass_r21_reflectix">Fiberglass R-21 + 2x Reflectix</option>
                                 <option value="mineral_wool">Mineral Wool</option>
                                 <option value="cellulose">Cellulose</option>
                                 <option value="havelock_wool">Havelock Wool (Sheep)</option>


### PR DESCRIPTION
Implemented user request to add "2x6 roof truss" and "basement subfloor 2 layers of reflectix permeable barrier with the r21" as selectable materials. These have been added to the Wall Assembly builder as "Wood Truss" (Framing) and "Fiberglass R-21 + 2x Reflectix" (Cavity Insulation) to allow R-value estimation using the existing interface. Verified via Playwright and unit tests.

---
*PR created automatically by Jules for task [909343033020976993](https://jules.google.com/task/909343033020976993) started by @creuzerm*